### PR TITLE
pass cachedir through to _start_engines

### DIFF
--- a/metapub/findit/findit.py
+++ b/metapub/findit/findit.py
@@ -59,11 +59,11 @@ FINDIT_CACHE = None
 
 pm_fetch = None
 
-def _start_engines():
+def _start_engines(cachedir):
     global pm_fetch
     if not pm_fetch:
         log.debug('Started PubMedFetcher engine.')
-        pm_fetch = PubMedFetcher()
+        pm_fetch = PubMedFetcher(cachedir=cachedir)
 
 def _get_findit_cache(cachedir):
     global FINDIT_CACHE
@@ -107,7 +107,7 @@ class FindIt(object):
 
     def __init__(self, pmid=None, cachedir=DEFAULT_CACHE_DIR, **kwargs):
 
-        _start_engines()
+        _start_engines(cachedir)
 
         self.pmid = pmid if pmid else kwargs.get('pmid', None)
         self.doi = kwargs.get('doi', None)


### PR DESCRIPTION
This PR fixes an issue blocking use of `FindIt` in circumstances where the caller doesn't have arbitrary filesystem write access (such as in a Lambda). Currently, the `FindIt` constructor accepts and uses a `cachedir` argument, but the `PubMedFetcher` instantiated in `_start_engines` ignores that argument. This PR simply passes the `cachedir` provided to the `FindIt` constructor through to the `PubMedFetcher`.